### PR TITLE
Update resource message

### DIFF
--- a/lua/entities/bcrafting_generalbench/cl_init.lua
+++ b/lua/entities/bcrafting_generalbench/cl_init.lua
@@ -66,7 +66,7 @@ net.Receive( "bCrafting_Net_UseBench", function( len, ply )
 			if( ResourceString != "" ) then
 				draw.SimpleText( ResourceString, "XeninUI.Crafting.Description", 15, h/2, Color(255,255,255,255), 0, TEXT_ALIGN_CENTER )
 			else
-				draw.SimpleText( "No resources, collect some from around the map!", "XeninUI.Crafting.Description", 15, h/2, Color(255,255,255,255), 0, TEXT_ALIGN_CENTER )
+				draw.SimpleText( "No resources, buy some from the hardware store!", "XeninUI.Crafting.Description", 15, h/2, Color(255,255,255,255), 0, TEXT_ALIGN_CENTER )
 			end
 		end
 

--- a/lua/entities/bcrafting_weaponsbench/cl_init.lua
+++ b/lua/entities/bcrafting_weaponsbench/cl_init.lua
@@ -63,7 +63,7 @@ net.Receive( "bCrafting_Net_WUseBench", function( len, ply )
 			if( ResourceString != "" ) then
 				draw.SimpleText( ResourceString, "XeninUI.Crafting.Description", 15, h/2, Color(255,255,255,255), 0, TEXT_ALIGN_CENTER )
 			else
-				draw.SimpleText( "No resources, collect some from around the map!", "XeninUI.Crafting.Description", 15, h/2, Color(255,255,255,255), 0, TEXT_ALIGN_CENTER )
+				draw.SimpleText( "No resources, buy some from the hardware store!", "XeninUI.Crafting.Description", 15, h/2, Color(255,255,255,255), 0, TEXT_ALIGN_CENTER )
 			end
 		end
 


### PR DESCRIPTION
Change the no resource message on the benches so it tells players to buy resources from the hardware store rather than search for them.