### PR TITLE
Changing spawning of Ammo to not to DarkRP's "spawned_weapon"

### DIFF
--- a/lua/autorun/bcrafting_autorun.lua
+++ b/lua/autorun/bcrafting_autorun.lua
@@ -110,6 +110,18 @@ if( SERVER ) then
         weapon.nodupe = true
         weapon:Spawn()
     end
+
+    function BCRAFTING.SpawnAmmo( bench, class )
+        local ammo = ents.Create(class)
+
+        local ammoAng = bench:GetAngles()
+        local ammoPos = bench:GetAngles():Up() * 60
+
+        ammo:SetPos(bench:GetPos() + ammoPos)
+        ammo:SetAngles(ammoAng)
+        ammo.nodupe = true
+        ammo:Spawn()
+    end
 elseif( CLIENT ) then
     net.Receive( "bCrafting_Net_Notify", function()
         local Message = net.ReadString()

--- a/lua/bcrafting_config.lua
+++ b/lua/bcrafting_config.lua
@@ -195,7 +195,7 @@ BCRAFTING.CONFIG.Weapons.Items[15] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 2, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_9x19"
+    AmmoClass = "cw_ammo_9x19"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[16] = {
@@ -203,7 +203,7 @@ BCRAFTING.CONFIG.Weapons.Items[16] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 2, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_9x17"
+    AmmoClass = "cw_ammo_9x17"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[17] = {
@@ -211,7 +211,7 @@ BCRAFTING.CONFIG.Weapons.Items[17] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 2, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_45acp"
+    AmmoClass = "cw_ammo_45acp"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[18] = {
@@ -219,7 +219,7 @@ BCRAFTING.CONFIG.Weapons.Items[18] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 3, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_545x39"
+    AmmoClass = "cw_ammo_545x39"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[19] = {
@@ -227,7 +227,7 @@ BCRAFTING.CONFIG.Weapons.Items[19] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 3, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_44magnum"
+    AmmoClass = "cw_ammo_44magnum"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[20] = {
@@ -235,7 +235,7 @@ BCRAFTING.CONFIG.Weapons.Items[20] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 3, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_12gauge"
+    AmmoClass = "cw_ammo_12gauge"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[21] = {
@@ -243,7 +243,7 @@ BCRAFTING.CONFIG.Weapons.Items[21] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 3, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_556x45"
+    AmmoClass = "cw_ammo_556x45"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[22] = {
@@ -251,7 +251,7 @@ BCRAFTING.CONFIG.Weapons.Items[22] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 3, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_50ae"
+    AmmoClass = "cw_ammo_50ae"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[23] = {
@@ -259,7 +259,7 @@ BCRAFTING.CONFIG.Weapons.Items[23] = {
     Description = "",
     Model = "models/Items/BoxMRounds.mdl",
     Resource = { ["Gunpowder"] = 4, ["Metal"] = 1 },
-    WeaponClass = "cw_ammo_762x51"
+    AmmoClass = "cw_ammo_762x51"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[24] = {

--- a/lua/bcrafting_config.lua
+++ b/lua/bcrafting_config.lua
@@ -267,7 +267,7 @@ BCRAFTING.CONFIG.Weapons.Items[24] = {
     Description = "",
     Model = "models/Items/BoxSRounds.mdl",
     Resource = { ["Plastic"] = 2, ["Metal"] = 1, ["Glass"] = 1 },
-    WeaponClass = "cw_attpack_sights_cqb"
+    AmmoClass = "cw_attpack_sights_cqb"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[25] = {
@@ -275,7 +275,7 @@ BCRAFTING.CONFIG.Weapons.Items[25] = {
     Description = "",
     Model = "models/Items/BoxSRounds.mdl",
     Resource = { ["Plastic"] = 1, ["Metal"] = 2, ["Glass"] = 2 },
-    WeaponClass = "cw_attpack_sights_midrange"
+    AmmoClass = "cw_attpack_sights_midrange"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[26] = {
@@ -283,7 +283,7 @@ BCRAFTING.CONFIG.Weapons.Items[26] = {
     Description = "",
     Model = "models/Items/BoxSRounds.mdl",
     Resource = { ["Plastic"] = 1, ["Metal"] = 3, ["Glass"] = 3 },
-    WeaponClass = "cw_attpack_sights_longrange"
+    AmmoClass = "cw_attpack_sights_longrange"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[27] = {
@@ -291,7 +291,7 @@ BCRAFTING.CONFIG.Weapons.Items[27] = {
     Description = "",
     Model = "models/Items/BoxSRounds.mdl",
     Resource = { ["Plastic"] = 2, ["Metal"] = 3, ["Glass"] = 4 },
-    WeaponClass = "cw_attpack_sights_sniper"
+    AmmoClass = "cw_attpack_sights_sniper"
 }
 
 BCRAFTING.CONFIG.Weapons.Items[28] = {
@@ -299,5 +299,5 @@ BCRAFTING.CONFIG.Weapons.Items[28] = {
     Description = "",
     Model = "models/Items/BoxSRounds.mdl",
     Resource = { ["Plastic"] = 4, ["Metal"] = 4},
-    WeaponClass = "cw_attpack_suppressors"
+    AmmoClass = "cw_attpack_suppressors"
 }

--- a/lua/entities/bcrafting_generalbench/init.lua
+++ b/lua/entities/bcrafting_generalbench/init.lua
@@ -9,7 +9,7 @@ function ENT:Initialize()
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
 	
-    local phys = self:GetPhysicsObject()
+	local phys = self:GetPhysicsObject()
 	if (phys:IsValid()) then
 		phys:Wake()
 	end
@@ -75,6 +75,10 @@ net.Receive( "bCrafting_Net_CraftItem", function( len, ply )
 
 		if( Item.WeaponClass ) then
 			BCRAFTING.SpawnItem( Bench, Item.WeaponClass )
+		end
+
+		if( Item.AmmoClass ) then
+			BCRAFTING.SpawnAmmo( Bench, Item.AmmoClass )
 		end
 
 		BCRAFTING.Notify( ply, "You have crafted the item '" .. Item.Name .. "'. It has been dropped on the workbench." )

--- a/lua/entities/bcrafting_weaponsbench/init.lua
+++ b/lua/entities/bcrafting_weaponsbench/init.lua
@@ -73,6 +73,10 @@ net.Receive( "bCrafting_Net_WCraftItem", function( len, ply )
 			BCRAFTING.SpawnItem( Bench, Item.WeaponClass )
 		end
 
+		if( Item.AmmoClass ) then
+			BCRAFTING.SpawnAmmo( Bench, Item.AmmoClass )
+		end
+
 		BCRAFTING.Notify( ply, "You have crafted the item '" .. Item.Name .. "'. It has been dropped on the workbench." )
 	else
 		BCRAFTING.Notify( ply, "You don't have enough resources to craft this item!" )


### PR DESCRIPTION
Ammo will be spawned as their normal gmod entity, meaning pressing E will not be required to pick them up, and they'll actually work.

Using `AmmoClass` instead of `WeaponClass` will trigger this alternate behaviour.

Unknown currently as to if CW attachments need this.